### PR TITLE
fix: BEIN-12758 fix undefined constant

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beincom/dto",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Share dto for all projects of Beincom",
   "main": "./dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beincom/dto",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Share dto for all projects of Beincom",
   "main": "./dist/index.js",
   "scripts": {

--- a/src/user.dto.ts
+++ b/src/user.dto.ts
@@ -44,12 +44,12 @@ export class UserDto {
 }
 
 export interface SharedUserDto {
-    id: string;
-    username: string;
-    fullname: string;
-    avatar: string;
-    email: string;
-    isDeactivated: boolean;
-    groups: string[];
+  id: string;
+  username: string;
+  fullname: string;
+  avatar: string;
+  email: string;
+  isDeactivated: boolean;
+  groups: string[];
 }
-export declare const SHARED_USER_KEY_PREFIX = "SU";
+export const SHARED_USER_KEY_PREFIX = "SU";


### PR DESCRIPTION
The declare keyword is used to tell the TypeScript compiler that the type or value has already been declared somewhere else, so it should not try to compile it again. -> undefined SHARED_USER_KEY_PREFIX